### PR TITLE
Correcting metrics and gracefulShudtdown in vertx4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
        options:
           max-file: "3"
           max-size: "5m"
-    command: bash -c "exec java $$FS_JAVA_OPTS  -jar ./fatjar.jar  --host $$(hostname) -c secrets/all-verticles-configs/config.json"
+    command: bash -c "exec java $$FS_JAVA_OPTS  -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.Log4j2LogDelegateFactory -jar ./fatjar.jar  --host $$(hostname) -c secrets/all-verticles-configs/config.json"
 
 volumes:
   fs-upload-volume:

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 		<vertx.version>4.0.3</vertx.version>
 		<openjdk.version>11</openjdk.version>
 		<hazelcast.version>4.0.2</hazelcast.version>
-		<micrometer.version>1.7.0</micrometer.version>
+		<micrometer.version>1.6.2</micrometer.version>
 		<curator.version>5.1.0</curator.version>
 		<maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
 		<junit-jupiter-api.version>5.7.2</junit-jupiter-api.version>
@@ -312,6 +312,8 @@
 									implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
 									<resource>META-INF/services/io.vertx.core.spi.VerticleFactory
 									</resource>
+									<resource>META-INF/services/io.vertx.core.spi.VertxServiceProvider
+									</resource>
 								</transformer>
 							</transformers>
 							<artifactSet></artifactSet>
@@ -348,6 +350,8 @@
 								<transformer
 									implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
 									<resource>META-INF/services/io.vertx.core.spi.VerticleFactory
+									</resource>
+									<resource>META-INF/services/io.vertx.core.spi.VertxServiceProvider
 									</resource>
 								</transformer>
 							</transformers>


### PR DESCRIPTION

- changing cluster manager leave method with promise as param instead of
  handler

- Correction of metrics in vertx4, by including 'META-INF/services/io.vertx.core.spi.VertxServiceProvider' in transformer in pom.xml,  [refer issue](https://github.com/eclipse-vertx/vert.x/issues/3772).

- Proper configuration of logging, so that vertx components also logs using log4j2, [refer docs](https://vertx.io/docs/vertx-core/java/#_logging).