### PR TITLE
Updated to refer configs archived for release 3.5.0 in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,7 +67,7 @@ pipeline {
           script{
             startZap ([host: 'localhost', port: 8090, zapHome: '/var/lib/jenkins/tools/com.cloudbees.jenkins.plugins.customtools.CustomTool/OWASP_ZAP/ZAP_2.11.0'])
               sh 'curl http://127.0.0.1:8090/JSON/pscan/action/disableScanners/?ids=10096'
-              sh 'HTTP_PROXY=\'127.0.0.1:8090\' newman run /var/lib/jenkins/iudx/fs/Newman/iudx-file-server-api.Release-v3.5.postman_collection.json -e /home/ubuntu/configs/fs-postman-env.json --insecure -r htmlextra --reporter-htmlextra-export /var/lib/jenkins/iudx/fs/Newman/report/report.html --reporter-htmlextra-skipSensitiveData'
+              sh 'HTTP_PROXY=\'127.0.0.1:8090\' newman run /var/lib/jenkins/iudx/fs/Newman/iudx-file-server-api.Release-v3.5.postman_collection.json -e /home/ubuntu/configs/3.5.0/fs-postman-env.json --insecure -r htmlextra --reporter-htmlextra-export /var/lib/jenkins/iudx/fs/Newman/report/report.html --reporter-htmlextra-skipSensitiveData'
             runZapAttack()
           }
         }

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -8,8 +8,8 @@ services:
     environment: 
       - LOG_LEVEL=INFO
     volumes:
-      - /home/ubuntu/configs/fs-config-test.json:/usr/share/app/secrets/all-verticles-configs/config-dev.json
-      - /home/ubuntu/configs/keystore-file.jks:/usr/share/app/secrets/keystore-file.jks
+      - /home/ubuntu/configs/3.5.0/fs-config-test.json:/usr/share/app/secrets/all-verticles-configs/config-dev.json
+      - /home/ubuntu/configs/3.5.0/keystore-file.jks:/usr/share/app/secrets/keystore-file.jks
       - ./docker/runTests.sh:/usr/share/app/docker/runTests.sh
       - ./example-configs/:/usr/share/app/example-configs
       - ./src/:/usr/share/app/src
@@ -24,8 +24,8 @@ services:
     environment:
       - LOG_LEVEL=INFO
     volumes:
-      - /home/ubuntu/configs/fs-config-test.json:/usr/share/app/secrets/all-verticles-configs/config-dev.json
-      - /home/ubuntu/configs/keystore-file.jks:/usr/share/app/secrets/keystore-file.jks
+      - /home/ubuntu/configs/3.5.0/fs-config-test.json:/usr/share/app/secrets/all-verticles-configs/config-dev.json
+      - /home/ubuntu/configs/3.5.0/keystore-file.jks:/usr/share/app/secrets/keystore-file.jks
       - ./src/:/usr/share/app/src
     command: bash -c "mvn clean compile exec:java@file-server"
     ports:


### PR DESCRIPTION
Until now the same config files were being used in all the pipelines (master/PR/3.5.0). But since testing the v4.0 components (master and PR CI) might require changes in the config files, it could end up affecting v3.5.0 CI pipelines.
To avoid this, archiving the current configs for the 3.5.0 pipelines separately and updated references in the CI tests to refer to those.