### PR TITLE
Dependencies/lib updates to latest stable releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<name>iudx-file-server</name>
 
 	<properties>
-		<vertx.version>4.0.3</vertx.version>
+		<vertx.version>4.3.2</vertx.version>
 		<openjdk.version>11</openjdk.version>
 		<hazelcast.version>4.0.2</hazelcast.version>
 		<micrometer.version>1.6.2</micrometer.version>

--- a/pom.xml
+++ b/pom.xml
@@ -11,31 +11,29 @@
 		<vertx.version>4.3.2</vertx.version>
 		<openjdk.version>11</openjdk.version>
 		<hazelcast.version>4.0.2</hazelcast.version>
-		<micrometer.version>1.6.2</micrometer.version>
-		<curator.version>5.1.0</curator.version>
+		<micrometer.version>1.9.2</micrometer.version>
+		<curator.version>5.3.0</curator.version>
 		<maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
-		<junit-jupiter-api.version>5.7.2</junit-jupiter-api.version>
-		<junit-jupiter-params.version>5.7.2</junit-jupiter-params.version>
-		<junit-jupiter-engine.version>5.7.2</junit-jupiter-engine.version>
-		<testcontainers.version>1.15.3</testcontainers.version>
-		<testcontainer-elastic.version>1.15.3</testcontainer-elastic.version>
-		<testcontainer-postgres.version>1.16.3</testcontainer-postgres.version>
+		<junit-jupiter-api.version>5.8.2</junit-jupiter-api.version>
+		<junit-jupiter-params.version>5.8.2</junit-jupiter-params.version>
+		<junit-jupiter-engine.version>5.8.2</junit-jupiter-engine.version>
+		<testcontainers.version>1.17.3</testcontainers.version>
+		<testcontainer-elastic.version>1.17.3</testcontainer-elastic.version>
+		<testcontainer-postgres.version>1.17.3</testcontainer-postgres.version>
 		<log4j2.version>2.17.1</log4j2.version>
 		<disruptor.version>3.4.4</disruptor.version>
-		<junit-jupiter.version>1.15.3</junit-jupiter.version>
+		<junit-jupiter.version>1.17.3</junit-jupiter.version>
 		<elasticsearch-rest-client.version>7.12.1</elasticsearch-rest-client.version>
 		<elasticsearch-rest-high-level-client.version>7.12.1</elasticsearch-rest-high-level-client.version>
-		<jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
-		<maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
-		<checkstyle.version>8.42</checkstyle.version>
-		<maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
-		<maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
+		<jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
+		<checkstyle.version>10.3.1</checkstyle.version>
+		<maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
+		<maven-javadoc-plugin.version>3.4.0</maven-javadoc-plugin.version>
 		<exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
-		<maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
-		<maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+		<maven-surefire-plugin.version>3.0.0-M7</maven-surefire-plugin.version>
+		<maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
 		<maven-pmd-plugin.version>3.14.0</maven-pmd-plugin.version>
-		<maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
-		<maven-surefire-report-plugin.version>3.0.0-M5</maven-surefire-report-plugin.version>
+		<maven-surefire-report-plugin.version>3.0.0-M7</maven-surefire-report-plugin.version>
 
 		<exec.mainClass>iudx.file.server.deploy.Deployer</exec.mainClass>
 		<exec.mainClassDev>iudx.file.server.deploy.DeployerDev</exec.mainClassDev>

--- a/src/main/java/iudx/file/server/apiserver/FileServerVerticle.java
+++ b/src/main/java/iudx/file/server/apiserver/FileServerVerticle.java
@@ -295,7 +295,7 @@ public class FileServerVerticle extends AbstractVerticle {
     StringBuilder uploadPath = new StringBuilder();
     uploadPath.append(fileIdComponent[1] + "/" + fileIdComponent[3]);
 
-    Set<FileUpload> files = routingContext.fileUploads();
+    List<FileUpload> files = routingContext.fileUploads();
     if (!isExternalStorage && (files.size() == 0 || !isValidFileContentType(files))) {
       handleResponse(response, HttpStatusCode.BAD_REQUEST);
       String message = new RestResponse.Builder()
@@ -341,7 +341,7 @@ public class FileServerVerticle extends AbstractVerticle {
    * @param filePath
    * @param id
    */
-  private void sampleFileUpload(HttpServerResponse response, Set<FileUpload> files,
+  private void sampleFileUpload(HttpServerResponse response, List<FileUpload> files,
       String fileName,
       String filePath, String id, JsonObject auditParams) {
 
@@ -374,7 +374,7 @@ public class FileServerVerticle extends AbstractVerticle {
    * @param id
    */
   private void archiveFileUpload(HttpServerResponse response, MultiMap params,
-      Set<FileUpload> files,
+      List<FileUpload> files,
       String filePath, String id, JsonObject auditParams) {
     JsonObject uploadJson = new JsonObject();
     JsonObject responseJson = new JsonObject();
@@ -781,7 +781,7 @@ public class FileServerVerticle extends AbstractVerticle {
   }
 
 
-  private boolean isValidFileContentType(Set<FileUpload> files) {
+  private boolean isValidFileContentType(List<FileUpload> files) {
     for (FileUpload file : files) {
       LOGGER.debug(file.contentType());
       if (!contentTypeValidator.isValid(file.contentType())) {

--- a/src/main/java/iudx/file/server/apiserver/service/FileService.java
+++ b/src/main/java/iudx/file/server/apiserver/service/FileService.java
@@ -1,5 +1,6 @@
 package iudx.file.server.apiserver.service;
 
+import java.util.List;
 import java.util.Set;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
@@ -16,7 +17,7 @@ public interface FileService {
    * @param file set of file (although there will always be a single file to upload)
    * @param handler
    */
-  Future<JsonObject> upload(final Set<FileUpload> file, String filePath);
+  Future<JsonObject> upload(final List<FileUpload> file, String filePath);
 
   /**
    * upload file to server
@@ -26,7 +27,7 @@ public interface FileService {
    * @param filePath path for uploaded file
    * @param handler
    */
-  Future<JsonObject> upload(final Set<FileUpload> file, String fileName, String filePath);
+  Future<JsonObject> upload(final List<FileUpload> file, String fileName, String filePath);
 
   /**
    * download file from server

--- a/src/main/java/iudx/file/server/apiserver/service/impl/LocalStorageFileServiceImpl.java
+++ b/src/main/java/iudx/file/server/apiserver/service/impl/LocalStorageFileServiceImpl.java
@@ -1,7 +1,7 @@
 package iudx.file.server.apiserver.service.impl;
 
 import java.util.Iterator;
-import java.util.Set;
+import java.util.List;
 import java.util.UUID;
 
 import iudx.file.server.apiserver.response.ResponseUrn;
@@ -38,7 +38,7 @@ public class LocalStorageFileServiceImpl implements FileService {
    * {@inheritDoc}
    */
   @Override
-  public Future<JsonObject> upload(Set<FileUpload> files, String filename, String filePath) {
+  public Future<JsonObject> upload(List<FileUpload> files, String filename, String filePath) {
     Promise<JsonObject> promise = Promise.promise();
     LOGGER.debug("uploading.. files to file system.");
     final JsonObject metadata = new JsonObject();
@@ -79,7 +79,7 @@ public class LocalStorageFileServiceImpl implements FileService {
   }
 
   @Override
-  public Future<JsonObject> upload(Set<FileUpload> files, String filePath) {
+  public Future<JsonObject> upload(List<FileUpload> files, String filePath) {
     return upload(files, UUID.randomUUID().toString(), filePath);
   }
 

--- a/src/test/java/iudx/file/server/apiserver/service/LocalFileStorageTest.java
+++ b/src/test/java/iudx/file/server/apiserver/service/LocalFileStorageTest.java
@@ -7,9 +7,8 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
@@ -20,7 +19,6 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
-
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -36,7 +34,6 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import iudx.file.server.apiserver.service.impl.LocalStorageFileServiceImpl;
 import iudx.file.server.mocks.FileUploadMock;
-import net.bytebuddy.implementation.bytecode.assign.primitive.VoidAwareAssigner;
 
 @ExtendWith({VertxExtension.class, MockitoExtension.class})
 public class LocalFileStorageTest {
@@ -74,10 +71,10 @@ public class LocalFileStorageTest {
     lenient().when(asyncResult.result()).thenReturn(new JsonObject().put("fileName", file.fileName()));
 
     LOGGER.debug(file.uploadedFileName());
-    Set<FileUpload> set = new HashSet<>();
-    set.add(file);
+    List<FileUpload> list = new ArrayList<>();
+    list.add(file);
 
-    Future<JsonObject> fut = fileService.upload(set, "mockFile.txt", "/abc");
+    Future<JsonObject> fut = fileService.upload(list, "mockFile.txt", "/abc");
     fut.onComplete(handler -> {
 
       JsonObject res = handler.result();
@@ -112,10 +109,10 @@ public class LocalFileStorageTest {
     lenient().when(asyncResult.failed()).thenReturn(true);
 
     LOGGER.debug(file.uploadedFileName());
-    Set<FileUpload> set = new HashSet<>();
-    set.add(file);
+    List<FileUpload> list = new ArrayList<>();
+    list.add(file);
 
-    Future<JsonObject> fut = fileService.upload(set, "mockFile.txt", "/abc");
+    Future<JsonObject> fut = fileService.upload(list, "mockFile.txt", "/abc");
     fut.onComplete(handler -> {
       assertTrue(handler.failed());
       verify(fs, times(1)).move(any(), any(), any(), any());


### PR DESCRIPTION
#### Dependencies/lib updates to latest stable releases

1.  Vertx version bump to 4.3.2 from 4.0.3
      -  Requires changing `Set<FileUploads>` to `List<FileUploads>`
2.  Dependencies upgraded to latest stable release

| dependency | old version | new version |
|:---:|---|---|
| micrometer | 1.6.2 | 1.9.2 |
| curator | 5.1.0 | 5.3.0 |
| junit-jupiter-api | 5.7.2 | 5.8.2 |
| junit-jupiter-engine | 5.7.2 | 5.8.2 |
| junit-jupiter-params | 5.7.2 | 5.8.2 |
| testcontainer | 1.15.3 | 1.17.3 |
| testcontainer-elastic | 1.15.3 | 1.17.3 |
| testcontainer-postgres | 1.15.3 | 1.17.3 |
| testcontainer-junit-jupiter | 1.15.3 | 1.17.3 |
| jacoco | 0.8.7 | 0.8.8 |
| checkstyle(puppycrawl) | 8.4.2 | 10.3.1 |
| shade plugin | 3.2.4 | 3.3.0 |
| javadocs plugin | 3.2.0 | 3.4.0 |
| exec plugin | 3.0.0 | 3.1.0 |
| surefire pluigin | 3.0.0-M5 | 3.0.0-M7 |
| mvn compile plugin | 3.8.1 | 3.10.1 |
| pmd plugin | 3.14.0 | 3.17.0 |
| surefire-plugin | 3.0.0-M5 | 3.0.0-M7 |