### PR TITLE
3.5.0: Removal of unused config option in fs

### DIFF
--- a/example-configs/config-depl.json
+++ b/example-configs/config-depl.json
@@ -45,8 +45,7 @@
 			"databaseIP": "localhost",
 			"databasePort": 9200,
 			"databaseUser": "elastic",
-			"databasePassword": "elk@elastic.in",
-			"databaseUsed": ""
+			"databasePassword": "elk@elastic.in"
 		},
 		{
 			"id": "iudx.file.server.database.postgres.PostgresVerticle",

--- a/example-configs/config-dev.json
+++ b/example-configs/config-dev.json
@@ -44,8 +44,7 @@
 			"databaseIP": "localhost",
 			"databasePort": 9200,
 			"databaseUser": "elastic",
-			"databasePassword": "elk@elastic.in",
-			"databaseUsed": ""
+			"databasePassword": "elk@elastic.in"
 		},
 		{
 			"id": "iudx.file.server.database.postgres.PostgresVerticle",

--- a/example-configs/config-test.json
+++ b/example-configs/config-test.json
@@ -53,8 +53,7 @@
             "databaseIP": "localhost",
             "databasePort": 9200,
             "databaseUser": "elastic",
-            "databasePassword": "elk@elastic.in",
-            "databaseUsed": ""
+            "databasePassword": "elk@elastic.in"
         },
         {
             "id": "iudx.file.server.database.postgres.PostgresVerticle",


### PR DESCRIPTION
- removal of 'databaseUsed' option as
grep -rnw src/ -e 'databaseUsed' yields no result
- Backport #95 to 3.5.0 branch