### PR TITLE
Jenkins v4.0.0 pipeline updates

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,7 +67,7 @@ pipeline {
           script{
             startZap ([host: 'localhost', port: 8090, zapHome: '/var/lib/jenkins/tools/com.cloudbees.jenkins.plugins.customtools.CustomTool/OWASP_ZAP/ZAP_2.11.0'])
               sh 'curl http://127.0.0.1:8090/JSON/pscan/action/disableScanners/?ids=10096'
-              sh 'HTTP_PROXY=\'127.0.0.1:8090\' newman run /var/lib/jenkins/iudx/fs/Newman/iudx-file-server-api.Release-v4.0.postman_collection.json -e /home/ubuntu/configs/fs-postman-env.json --insecure -r htmlextra --reporter-htmlextra-export /var/lib/jenkins/iudx/fs/Newman/report/report.html --reporter-htmlextra-skipSensitiveData'
+              sh 'HTTP_PROXY=\'127.0.0.1:8090\' newman run /var/lib/jenkins/iudx/fs/Newman/iudx-file-server-api.Release-v4.0.postman_collection.json -e /home/ubuntu/configs/4.0.0/fs-postman-env.json --insecure -r htmlextra --reporter-htmlextra-export /var/lib/jenkins/iudx/fs/Newman/report/report.html --reporter-htmlextra-skipSensitiveData'
             runZapAttack()
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,7 +63,7 @@ pipeline {
 
     stage('Integration tests & OWASP ZAP pen test'){
       steps{
-        node('master') {
+        node('built-in') {
           script{
             startZap ([host: 'localhost', port: 8090, zapHome: '/var/lib/jenkins/tools/com.cloudbees.jenkins.plugins.customtools.CustomTool/OWASP_ZAP/ZAP_2.11.0'])
               sh 'curl http://127.0.0.1:8090/JSON/pscan/action/disableScanners/?ids=10096'
@@ -74,11 +74,11 @@ pipeline {
       }
       post{
         always{
-          node('master') {
+          node('built-in') {
             script{
+              publishHTML([allowMissing: false, alwaysLinkToLastBuild: true, keepAll: true, reportDir: '/var/lib/jenkins/iudx/fs/Newman/report/', reportFiles: 'report.html', reportTitles: '', reportName: 'Integration Test Report'])
               archiveZap failHighAlerts: 1, failMediumAlerts: 1, failLowAlerts: 1
             }  
-            publishHTML([allowMissing: false, alwaysLinkToLastBuild: true, keepAll: true, reportDir: '/var/lib/jenkins/iudx/fs/Newman/report/', reportFiles: 'report.html', reportTitles: '', reportName: 'Integration Test Report'])
           }
         }
         failure{
@@ -92,66 +92,19 @@ pipeline {
       }
     }
 
-    stage('Continuous Deployment') {
-      when {
-        allOf {
-          anyOf {
-            changeset "docker/**"
-            changeset "docs/**"
-            changeset "pom.xml"
-            changeset "src/main/**"
-            triggeredBy cause: 'UserIdCause'
-          }
-          expression {
-            return env.GIT_BRANCH == 'origin/master';
-          }
+    stage('Push Image') {
+      when{
+        expression {
+          return env.GIT_BRANCH == 'origin/4.0.0';
         }
       }
-      stages {
-        stage('Push Images') {
-          steps {
-            script {
-              docker.withRegistry( registryUri, registryCredential ) {
-                devImage.push("4.0-alpha-${env.GIT_HASH}")
-                deplImage.push("4.0-alpha-${env.GIT_HASH}")
-              }
-            }
+      steps{
+        script {
+          docker.withRegistry( registryUri, registryCredential ) {
+            devImage.push("4.0.0-${env.GIT_HASH}")
+            deplImage.push("4.0.0-${env.GIT_HASH}")
           }
         }
-        stage('Docker Swarm deployment') {
-          steps {
-            script {
-              sh "ssh azureuser@docker-swarm 'docker service update file-server_file-server --image ghcr.io/datakaveri/fs-depl:4.0-alpha-${env.GIT_HASH}'"
-              sh 'sleep 10'
-            }
-          }
-          post{
-            failure{
-              error "Failed to deploy image in Docker Swarm"
-            }
-          }          
-        }
-        // stage('Integration test on swarm deployment') {
-        //   steps {
-        //     node('master') {
-        //       script{
-        //         sh 'newman run /var/lib/jenkins/iudx/fs/Newman/iudx-file-server-api.Release-v3.5.postman_collection.json -e /home/ubuntu/configs/cd/fs-postman-env.json --insecure -r htmlextra --reporter-htmlextra-export /var/lib/jenkins/iudx/fs/Newman/report/cd-report.html --reporter-htmlextra-skipSensitiveData'
-        //       }
-        //     }
-        //   }
-        //   post{
-        //     always{
-        //       node('master') {
-        //         script{
-        //           publishHTML([allowMissing: false, alwaysLinkToLastBuild: true, keepAll: true, reportDir: '/var/lib/jenkins/iudx/fs/Newman/report/', reportFiles: 'cd-report.html', reportTitles: '', reportName: 'Docker-Swarm Integration Test Report'])
-        //         }
-        //       }
-        //     }
-        //     failure{
-        //       error "Test failure. Stopping pipeline execution!"
-        //     }
-        //   }
-        // }
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-[![Build Status](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fjenkins.iudx.io%2Fjob%2Fiudx%2520file-server%2520%28master%29%2520pipeline%2F)](https://jenkins.iudx.io/job/iudx%20file-server%20(master)%20pipeline/lastBuild/)
-[![Jenkins Coverage](https://img.shields.io/jenkins/coverage/jacoco?jobUrl=https%3A%2F%2Fjenkins.iudx.io%2Fjob%2Fiudx%2520file-server%2520%28master%29%2520pipeline%2F)](https://jenkins.iudx.io/job/iudx%20file-server%20(master)%20pipeline/lastBuild/jacoco/)
-[![Unit Tests](https://img.shields.io/jenkins/tests?jobUrl=https%3A%2F%2Fjenkins.iudx.io%2Fjob%2Fiudx%2520file-server%2520%28master%29%2520pipeline%2F)](https://jenkins.iudx.io/job/iudx%20file-server%20(master)%20pipeline/lastBuild/testReport/)
-[![Performance Tests](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fjenkins.iudx.io%2Fjob%2Fiudx%2520file-server%2520%28master%29%2520pipeline%2F&label=performance%20tests)](https://jenkins.iudx.io/job/iudx%20file-server%20(master)%20pipeline/lastBuild/performance/)
-[![Security Tests](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fjenkins.iudx.io%2Fjob%2Fiudx%2520file-server%2520%28master%29%2520pipeline%2F&label=security%20tests)](https://jenkins.iudx.io/job/iudx%20file-server%20(master)%20pipeline/lastBuild/zap/)
-[![Integration Tests](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fjenkins.iudx.io%2Fjob%2Fiudx%2520file-server%2520%28master%29%2520pipeline%2F&label=integration%20tests)](https://jenkins.iudx.io/job/iudx%20file-server%20(master)%20pipeline/HTML_20Report/)
+[![Build Status](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fjenkins.iudx.io%2Fjob%2Fiudx%2520file-server%2520%28v4.0.0%29%2520pipeline%2F)](https://jenkins.iudx.io/job/iudx%20file-server%20(v4.0.0)%20pipeline/lastBuild/)
+[![Jenkins Coverage](https://img.shields.io/jenkins/coverage/jacoco?jobUrl=https%3A%2F%2Fjenkins.iudx.io%2Fjob%2Fiudx%2520file-server%2520%28v4.0.0%29%2520pipeline%2F)](https://jenkins.iudx.io/job/iudx%20file-server%20(v4.0.0)%20pipeline/lastBuild/jacoco/)
+[![Unit Tests](https://img.shields.io/jenkins/tests?jobUrl=https%3A%2F%2Fjenkins.iudx.io%2Fjob%2Fiudx%2520file-server%2520%28v4.0.0%29%2520pipeline%2F)](https://jenkins.iudx.io/job/iudx%20file-server%20(v4.0.0)%20pipeline/lastBuild/testReport/)
+[![Performance Tests](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fjenkins.iudx.io%2Fjob%2Fiudx%2520file-server%2520%28v4.0.0%29%2520pipeline%2F&label=performance%20tests)](https://jenkins.iudx.io/job/iudx%20file-server%20(v4.0.0)%20pipeline/lastBuild/performance/)
+[![Security Tests](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fjenkins.iudx.io%2Fjob%2Fiudx%2520file-server%2520%28v4.0.0%29%2520pipeline%2F&label=security%20tests)](https://jenkins.iudx.io/job/iudx%20file-server%20(v4.0.0)%20pipeline/lastBuild/zap/)
+[![Integration Tests](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fjenkins.iudx.io%2Fjob%2Fiudx%2520file-server%2520%28v4.0.0%29%2520pipeline%2F&label=integration%20tests)](https://jenkins.iudx.io/job/iudx%20file-server%20(v4.0.0)%20pipeline/HTML_20Report/)
 
 ![IUDX](./docs/iudx.png)
 
@@ -88,8 +88,8 @@ Find the installations of the above along with the configurations to modify the 
          ```
    2. Clustered setup with all verticles running in a single container: 
       - This needs following things:
-         - Docker swarm and overlay network having a name 'overlay-net'. Refer [here](https://github.com/datakaveri/iudx-deployment/tree/master/docs/swarm-setup.md)
-         - Zookeeper running in 'overlay-net' named overlay network. Refer [here](https://github.com/datakaveri/iudx-deployment/tree/master/single-node/zookeeper)
+         - Docker swarm and overlay network having a name 'overlay-net'. Refer [here](https://github.com/datakaveri/iudx-deployment/tree/v4.0.0/docs/swarm-setup.md)
+         - Zookeeper running in 'overlay-net' named overlay network. Refer [here](https://github.com/datakaveri/iudx-deployment/tree/v4.0.0/single-node/zookeeper)
       - This makes use of iudx/fs-depl:latest image and config-depl.json present at `secrets/all-verticles-configs/config-depl.json`
          ```sh 
          # Command to bring up the clustered one file-server container

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -31,3 +31,12 @@ services:
       - "8443:8443"
     networks:
       - fs-net
+    depends_on:
+      - "zookeeper"  
+  
+  zookeeper:
+    image: zookeeper:latest
+    expose: 
+      - "2181"
+    networks:
+      - di-net

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -8,8 +8,8 @@ services:
     environment: 
       - LOG_LEVEL=INFO
     volumes:
-      - /home/ubuntu/configs/fs-config-test.json:/usr/share/app/secrets/all-verticles-configs/config-dev.json
-      - /home/ubuntu/configs/keystore-file.jks:/usr/share/app/secrets/keystore-file.jks
+      - /home/ubuntu/configs/4.0.0/fs-config-test.json:/usr/share/app/secrets/all-verticles-configs/config-dev.json
+      - /home/ubuntu/configs/4.0.0/keystore-file.jks:/usr/share/app/secrets/keystore-file.jks
       - ./docker/runTests.sh:/usr/share/app/docker/runTests.sh
       - ./example-configs/:/usr/share/app/example-configs
       - ./src/:/usr/share/app/src
@@ -24,8 +24,8 @@ services:
     environment:
       - LOG_LEVEL=INFO
     volumes:
-      - /home/ubuntu/configs/fs-config-test.json:/usr/share/app/secrets/all-verticles-configs/config.json
-      - /home/ubuntu/configs/keystore-file.jks:/usr/share/app/secrets/keystore-file.jks
+      - /home/ubuntu/configs/4.0.0/fs-config-test.json:/usr/share/app/secrets/all-verticles-configs/config.json
+      - /home/ubuntu/configs/4.0.0/keystore-file.jks:/usr/share/app/secrets/keystore-file.jks
     command: bash -c "exec java $$FS_JAVA_OPTS  -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.Log4j2LogDelegateFactory -jar ./fatjar.jar  --host $$(hostname) -c secrets/all-verticles-configs/config.json"
     ports:
       - "8443:8443"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -20,14 +20,13 @@ services:
     network_mode: host
 
   integTest:
-    image: ghcr.io/datakaveri/fs-test:latest
+    image: ghcr.io/datakaveri/fs-depl:latest
     environment:
       - LOG_LEVEL=INFO
     volumes:
-      - /home/ubuntu/configs/fs-config-test.json:/usr/share/app/secrets/all-verticles-configs/config-dev.json
+      - /home/ubuntu/configs/fs-config-test.json:/usr/share/app/secrets/all-verticles-configs/config.json
       - /home/ubuntu/configs/keystore-file.jks:/usr/share/app/secrets/keystore-file.jks
-      - ./src/:/usr/share/app/src
-    command: bash -c "mvn clean compile exec:java@file-server"
+    command: bash -c "exec java $$FS_JAVA_OPTS  -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.Log4j2LogDelegateFactory -jar ./fatjar.jar  --host $$(hostname) -c secrets/all-verticles-configs/config.json"
     ports:
       - "8443:8443"
     networks:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -39,4 +39,4 @@ services:
     expose: 
       - "2181"
     networks:
-      - di-net
+      - fs-net


### PR DESCRIPTION
- fixed jenkins node label
- updated image tag to `4.0.0-${env.GIT_HASH}`
- archived 4.0.0 configs and updated references
- updated to use depl image for integration test stage
- Updated git badges to point to 4.0.0 pipelines