### PR TITLE
Make Catalogue Server, AAA Server basepaths configurable

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -29,7 +29,9 @@ info:
     - **Base path**:
       - Base path is the path on which API is served, relative to the host
       - It is the initial part of the API
-      - The base path value could be configured according to the deployment
+      - These base path values could be configured according to the deployment
+      - The base path for [DX AAA Server](https://github.com/datakaveri/iudx-aaa-server) is set to `/auth/v1`
+      - The base path for [DX Catalogue Server](https://github.com/datakaveri/iudx-catalogue-server) is set to `/iudx/cat/v1`
       - Currently, the following APIs have `/ngsi-ld/v1` base path
           -  /temporal/entities
           -  /entities

--- a/example-configs/config-dev.json
+++ b/example-configs/config-dev.json
@@ -6,7 +6,9 @@
 	"clusterId": "iudx-fs-cluster",
 	"commonConfig" :  {
 		"dxApiBasePath" : "/ngsi-ld/v1",
-		"iudxApiBasePath" : "/iudx/v1"
+		"iudxApiBasePath" : "/iudx/v1",
+		"dxCatalogueBasePath": "/iudx/cat/v1",
+		"dxAuthBasePath": "/auth/v1"
 	},
 	"modules": [
 		{

--- a/src/main/java/iudx/file/server/apiserver/FileServerVerticle.java
+++ b/src/main/java/iudx/file/server/apiserver/FileServerVerticle.java
@@ -115,6 +115,8 @@ public class FileServerVerticle extends AbstractVerticle {
   private CatalogueService catalogueService;
   private String dxApiBasePath;
   private String dxV1BasePath;
+  private String dxCatalogueBasePath;
+  private String dxAuthBasePath;
   private final ValidationFailureHandler validationsFailureHandler = new ValidationFailureHandler();
 
   @Override
@@ -142,6 +144,8 @@ public class FileServerVerticle extends AbstractVerticle {
 
     dxApiBasePath = config().getString("dxApiBasePath");
     dxV1BasePath = config().getString("iudxApiBasePath");
+    dxCatalogueBasePath = config().getString("dxCatalogueBasePath");
+    dxAuthBasePath = config().getString("dxAuthBasePath");
     Api api = Api.getInstance(dxApiBasePath,dxV1BasePath);
 
     router = Router.router(vertx);

--- a/src/main/java/iudx/file/server/authenticator/AuthenticationVerticle.java
+++ b/src/main/java/iudx/file/server/authenticator/AuthenticationVerticle.java
@@ -82,7 +82,8 @@ public class AuthenticationVerticle extends AbstractVerticle {
   private Future<String> getJwtPublicKey(Vertx vertx, JsonObject config) {
     Promise<String> promise = Promise.promise();
     webClient = createWebClient(vertx, config);
-    webClient.get(443, config.getString("authHost"), "/auth/v1/cert").send(handler -> {
+    String authCert = config.getString("dxAuthBasePath") + AUTH_CERTIFICATE_PATH;
+    webClient.get(443, config.getString("authHost"), authCert).send(handler -> {
       if (handler.succeeded()) {
         JsonObject json = handler.result().bodyAsJsonObject();
         promise.complete(json.getString("cert"));

--- a/src/main/java/iudx/file/server/authenticator/JwtAuthenticationServiceImpl.java
+++ b/src/main/java/iudx/file/server/authenticator/JwtAuthenticationServiceImpl.java
@@ -6,6 +6,8 @@ import static iudx.file.server.authenticator.utilities.Constants.JSON_IID;
 import static iudx.file.server.authenticator.utilities.Constants.JSON_USERID;
 import static iudx.file.server.authenticator.utilities.Constants.OPEN_ENDPOINTS;
 import static iudx.file.server.authenticator.utilities.Constants.QUERY_ENDPOINTS;
+import static iudx.file.server.common.Constants.CAT_SEARCH_PATH;
+
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -54,6 +56,7 @@ public class JwtAuthenticationServiceImpl implements AuthenticationService {
   final int port;;
   final String audience;
   final String path;
+  final String catBasePath;
   final CatalogueService catalogueService;
   final CacheService cache;
   final Api api;
@@ -80,7 +83,8 @@ public class JwtAuthenticationServiceImpl implements AuthenticationService {
     this.cache = cacheService;
     host = config.getString("catalogueHost");
     port = config.getInteger("cataloguePort");
-    this.path = Constants.CAT_RSG_PATH;
+    this.catBasePath = config.getString("dxCatalogueBasePath");
+    this.path = catBasePath + CAT_SEARCH_PATH;
     this.api = api;
 
     WebClientOptions options = new WebClientOptions();

--- a/src/main/java/iudx/file/server/common/Constants.java
+++ b/src/main/java/iudx/file/server/common/Constants.java
@@ -20,8 +20,11 @@ public class Constants {
   public static final String JSON_TIMEREL = "timerel";
 
   public static final long CACHE_TIMEOUT_AMOUNT = 30;
-  public static final String CAT_RSG_PATH = "/iudx/cat/v1/search";
-  public static final String CAT_ITEM_PATH = "/iudx/cat/v1/item";
+//  public static final String CAT_RSG_PATH = "/iudx/cat/v1/search";
+  public static final String CAT_SEARCH_PATH = "/search";
+
+  public static final String CAT_ITEM_PATH = "/item";
+  public static final String AUTH_CERTIFICATE_PATH = "/cert";
 
 
   // pagination parameters

--- a/src/main/java/iudx/file/server/common/service/impl/CatalogueServiceImpl.java
+++ b/src/main/java/iudx/file/server/common/service/impl/CatalogueServiceImpl.java
@@ -33,7 +33,9 @@ public class CatalogueServiceImpl implements CatalogueService {
   private String host;
   private int port;
 
-
+  private String catBasePath;
+  private String catItemPath;
+  private String catSearchPath;
   private final Cache<String, List<String>> applicableFilterCache =
       CacheBuilder.newBuilder().maximumSize(1000)
           .expireAfterAccess(CACHE_TIMEOUT_AMOUNT, TimeUnit.MINUTES).build();
@@ -42,6 +44,9 @@ public class CatalogueServiceImpl implements CatalogueService {
     this.webClient = webClientFactory.getWebClientFor(ServerType.FILE_SERVER);
     this.host = config.getString("catalogueHost");
     this.port = config.getInteger("cataloguePort");
+    catBasePath = config.getString("dxCatalogueBasePath");
+    catItemPath = catBasePath + CAT_ITEM_PATH;
+    catSearchPath = catBasePath + CAT_SEARCH_PATH;
   }
 
   @Override
@@ -130,8 +135,8 @@ public class CatalogueServiceImpl implements CatalogueService {
         });
         handler.handle(Future.succeededFuture(filters));
       } else if (catHandler.failed()) {
-        LOGGER.error("catalogue call(/iudx/cat/v1/item) failed for id" + id);
-        handler.handle(Future.failedFuture("catalogue call(/iudx/cat/v1/item) failed for id" + id));
+        LOGGER.error("catalogue call ("+ catItemPath + ") failed for id" + id);
+        handler.handle(Future.failedFuture("catalogue call(" + catItemPath + ") failed for id" + id));
       }
     });
   }

--- a/src/main/java/iudx/file/server/common/service/impl/CatalogueServiceImpl.java
+++ b/src/main/java/iudx/file/server/common/service/impl/CatalogueServiceImpl.java
@@ -124,7 +124,7 @@ public class CatalogueServiceImpl implements CatalogueService {
 
   private void callCatalogueAPI(String id, Handler<AsyncResult<List<String>>> handler) {
     List<String> filters = new ArrayList<String>();
-    webClient.get(port, host, CAT_ITEM_PATH).addQueryParam("id", id).send(catHandler -> {
+    webClient.get(port, host, catItemPath).addQueryParam("id", id).send(catHandler -> {
       if (catHandler.succeeded()) {
         JsonArray response = catHandler.result().bodyAsJsonObject().getJsonArray("results");
         response.forEach(json -> {
@@ -154,7 +154,7 @@ public class CatalogueServiceImpl implements CatalogueService {
     LOGGER.debug("isItemExist() started");
     Promise<Boolean> promise = Promise.promise();
     LOGGER.info("id : " + id);
-    webClient.get(port, host, CAT_ITEM_PATH).addQueryParam("id", id)
+    webClient.get(port, host, catItemPath).addQueryParam("id", id)
         .expect(ResponsePredicate.JSON).send(responseHandler -> {
           if (responseHandler.succeeded()) {
             HttpResponse<Buffer> response = responseHandler.result();

--- a/src/test/java/iudx/file/server/authenticator/JwtAuthServiceTest.java
+++ b/src/test/java/iudx/file/server/authenticator/JwtAuthServiceTest.java
@@ -92,7 +92,8 @@ public class JwtAuthServiceTest {
     authConfig.put("host", "rs.iudx.io");
     authConfig.put("dxApiBasePath","/ngsi-ld/v1");
     authConfig.put("iudxApiBasePath","/iudx/v1");
-
+    authConfig.put("dxCatalogueBasePath", "/iudx/cat/v1");
+    authConfig.put("dxAuthBasePath", "/auth/v1");
 
 
     JWTAuthOptions jwtAuthOptions = new JWTAuthOptions();

--- a/src/test/resources/FS.postman_environment.json
+++ b/src/test/resources/FS.postman_environment.json
@@ -45,6 +45,11 @@
 			"enabled": true
 		},
 		{
+			"key": "dxAuthBasePath",
+			"value": "auth/v1",
+			"enabled": true
+		},
+		{
 			"key": "auth-url",
 			"value": "authvertx.iudx.io",
 			"type": "default",

--- a/src/test/resources/README.md
+++ b/src/test/resources/README.md
@@ -1,8 +1,8 @@
 ### Making configurable base path
 - Base path can be added in postman environment file or in postman.
-- `FS.postman_environment.json` has **values** array which have fields named **dxApiBasePath** whose **value** is currently set to `ngsi-ld/v1`, **iudxApiBasePath** with value `iudx/v1`.
+- `FS.postman_environment.json` has **values** array which have fields named **dxApiBasePath** whose **value** is currently set to `ngsi-ld/v1`, **iudxApiBasePath** with value `iudx/v1`, **dxAuthBasePath** with value `auth/v1`.
 - The **value** could be changed according to the deployment and then the collection with the `FS.postman_environment.json` file can be uploaded to Postman
-- For the changing **dxApiBasePath**,**iudxApiBasePath** values in postman after importing the collection and environment files, locate `FS Environment` from **Environments** in sidebar of Postman application.
+- For the changing **dxApiBasePath**,**iudxApiBasePath**, **dxAuthBasePath** values in postman after importing the collection and environment files, locate `FS Environment` from **Environments** in sidebar of Postman application.
 - To know more about Postman environments, refer : [postman environments](https://learning.postman.com/docs/sending-requests/managing-environments/)
 - The **CURRENT VALUE** of the variable could be changed
 

--- a/src/test/resources/iudx-file-server-api.Release-v4.0.postman_collection.json
+++ b/src/test/resources/iudx-file-server-api.Release-v4.0.postman_collection.json
@@ -49,13 +49,13 @@
 							}
 						},
 						"url": {
-							"raw": "https://{{auth-url}}/{{dxApiBasePath}}/token",
+							"raw": "https://{{auth-url}}/{{dxAuthBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"{{auth-url}}"
 							],
 							"path": [
-								"{{dxApiBasePath}}",
+								"{{dxAuthBasePath}}",
 								"token"
 							]
 						}
@@ -116,13 +116,13 @@
 							}
 						},
 						"url": {
-							"raw": "https://{{auth-url}}/{{dxApiBasePath}}/token",
+							"raw": "https://{{auth-url}}/{{dxAuthBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"{{auth-url}}"
 							],
 							"path": [
-								"{{dxApiBasePath}}",
+								"{{dxAuthBasePath}}",
 								"token"
 							]
 						}
@@ -183,13 +183,13 @@
 							}
 						},
 						"url": {
-							"raw": "https://{{auth-url}}/{{dxApiBasePath}}/token",
+							"raw": "https://{{auth-url}}/{{dxAuthBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"{{auth-url}}"
 							],
 							"path": [
-								"{{dxApiBasePath}}",
+								"{{dxAuthBasePath}}",
 								"token"
 							]
 						}
@@ -250,13 +250,13 @@
 							}
 						},
 						"url": {
-							"raw": "https://{{auth-url}}/{{dxApiBasePath}}/token",
+							"raw": "https://{{auth-url}}/{{dxAuthBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"{{auth-url}}"
 							],
 							"path": [
-								"{{dxApiBasePath}}",
+								"{{dxAuthBasePath}}",
 								"token"
 							]
 						}
@@ -317,13 +317,13 @@
 							}
 						},
 						"url": {
-							"raw": "https://{{auth-url}}/{{dxApiBasePath}}/token",
+							"raw": "https://{{auth-url}}/{{dxAuthBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"{{auth-url}}"
 							],
 							"path": [
-								"{{dxApiBasePath}}",
+								"{{dxAuthBasePath}}",
 								"token"
 							]
 						}
@@ -384,13 +384,13 @@
 							}
 						},
 						"url": {
-							"raw": "https://{{auth-url}}/{{dxApiBasePath}}/token",
+							"raw": "https://{{auth-url}}/{{dxAuthBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"{{auth-url}}"
 							],
 							"path": [
-								"{{dxApiBasePath}}",
+								"{{dxAuthBasePath}}",
 								"token"
 							]
 						}

--- a/src/test/resources/iudx-file-server-api.Release-v4.0.postman_collection.json
+++ b/src/test/resources/iudx-file-server-api.Release-v4.0.postman_collection.json
@@ -49,14 +49,13 @@
 							}
 						},
 						"url": {
-							"raw": "https://{{auth-url}}/auth/v1/token",
+							"raw": "https://{{auth-url}}/{{dxApiBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"{{auth-url}}"
 							],
 							"path": [
-								"auth",
-								"v1",
+								"{{dxApiBasePath}}",
 								"token"
 							]
 						}
@@ -117,14 +116,13 @@
 							}
 						},
 						"url": {
-							"raw": "https://{{auth-url}}/auth/v1/token",
+							"raw": "https://{{auth-url}}/{{dxApiBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"{{auth-url}}"
 							],
 							"path": [
-								"auth",
-								"v1",
+								"{{dxApiBasePath}}",
 								"token"
 							]
 						}
@@ -185,14 +183,13 @@
 							}
 						},
 						"url": {
-							"raw": "https://{{auth-url}}/auth/v1/token",
+							"raw": "https://{{auth-url}}/{{dxApiBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"{{auth-url}}"
 							],
 							"path": [
-								"auth",
-								"v1",
+								"{{dxApiBasePath}}",
 								"token"
 							]
 						}
@@ -253,14 +250,13 @@
 							}
 						},
 						"url": {
-							"raw": "https://{{auth-url}}/auth/v1/token",
+							"raw": "https://{{auth-url}}/{{dxApiBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"{{auth-url}}"
 							],
 							"path": [
-								"auth",
-								"v1",
+								"{{dxApiBasePath}}",
 								"token"
 							]
 						}
@@ -321,14 +317,13 @@
 							}
 						},
 						"url": {
-							"raw": "https://{{auth-url}}/auth/v1/token",
+							"raw": "https://{{auth-url}}/{{dxApiBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"{{auth-url}}"
 							],
 							"path": [
-								"auth",
-								"v1",
+								"{{dxApiBasePath}}",
 								"token"
 							]
 						}
@@ -389,14 +384,13 @@
 							}
 						},
 						"url": {
-							"raw": "https://{{auth-url}}/auth/v1/token",
+							"raw": "https://{{auth-url}}/{{dxApiBasePath}}/token",
 							"protocol": "https",
 							"host": [
 								"{{auth-url}}"
 							],
 							"path": [
-								"auth",
-								"v1",
+								"{{dxApiBasePath}}",
 								"token"
 							]
 						}


### PR DESCRIPTION
- Referencing datakaveri/iudx-resource-server#368
- Made Catalogue Server base path `iudx/cat/v1`, AAA Server base path `auth/v1` configurable by [updating the files](https://github.com/datakaveri/iudx-file-server/pull/125/commits/68c0dd2ece4ac328bf02716d53b88a1a59226ef5)
- Changes in config-dev : 
```
	"commonConfig" :  {
		"dxApiBasePath" : "/ngsi-ld/v1",
		"iudxApiBasePath" : "/iudx/v1",
		"dxCatalogueBasePath": "/iudx/cat/v1",
		"dxAuthBasePath": "/auth/v1"
	}
```
- Changes in Postman environment file : 
```
	{
		"key": "dxAuthBasePath",
		"value": "auth/v1",
		"enabled": true
        }
```