### PR TITLE
remove extra fields from config

### DIFF
--- a/example-configs/config-dev.json
+++ b/example-configs/config-dev.json
@@ -89,14 +89,7 @@
 		},
 		{
 			"id": "iudx.file.server.auditing.AuditingVerticle",
-			"verticleInstances": 1,
-			"auditingDatabaseIP": "",
-			"auditingDatabasePort": 32508,
-			"auditingDatabaseName": "",
-			"auditingDatabaseUserName": "",
-			"auditingDatabasePassword": "",
-			"auditingDatabaseTableName": "",
-			"auditingPoolSize": 25
+			"verticleInstances": 1
 		}
 	]
 }


### PR DESCRIPTION
Note: since file server only have a write method in in auditing so, no need to extra fields  under AuditingVerticle in config.  